### PR TITLE
feat: adiciona configuração para o mongodb

### DIFF
--- a/php81/hyperf-php8-swoole52-dev/Dockerfile
+++ b/php81/hyperf-php8-swoole52-dev/Dockerfile
@@ -3,4 +3,5 @@ FROM marciodojr/hyperf-php8.1-swoole5.0.2
 COPY xdebug.ini /etc/php81/conf.d/00_xdebug.ini
 
 RUN apk update && apk upgrade \
-    && apk add php81-xdebug
+    && apk add php81-xdebug \
+    && apk add php81-mongodb \

--- a/php81/hyperf-php8-swoole52-dev/Makefile
+++ b/php81/hyperf-php8-swoole52-dev/Makefile
@@ -1,0 +1,4 @@
+build:
+	docker build --no-cache -t marciodojr/hyperf-php8-swoole52-dev .
+push:
+	docker push marciodojr/hyperf-php8-swoole52-dev

--- a/php81/hyperf-php8-swoole52-dev/test/docker-compose.yml
+++ b/php81/hyperf-php8-swoole52-dev/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   php:
-    image: marciodojr/hyperf-php8.1-swoole5.0.2
+    image: marciodojr/hyperf-php8-swoole52-dev
     container_name: php81-swoole52-xdebug
     environment:
       - MY_ENV_VAR=1


### PR DESCRIPTION
Essa solicitação de mesclagem adiciona configurações para habilitar a extensão do `mongodb` no PHP. Essas configurações já foram validadas e testadas localmente. O principal intuito dessa configuração é fazer com que não ocorra erros CI